### PR TITLE
bugfix: Getting last sequence_num on empty journal results to NPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 .DS_Store
 .bloop
 .java-version
+*.iml
 
 # Ignore Gradle build output directory
 build

--- a/docs/manual/advanced/aggregatestore.html
+++ b/docs/manual/advanced/aggregatestore.html
@@ -281,7 +281,7 @@ public class BankAggregateStore extends DefaultAggregateStore&lt;Account, BankEv
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/advanced/event-ordering.html
+++ b/docs/manual/advanced/event-ordering.html
@@ -228,7 +228,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/advanced/event-replay.html
+++ b/docs/manual/advanced/event-replay.html
@@ -219,7 +219,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/advanced/index.html
+++ b/docs/manual/advanced/index.html
@@ -198,7 +198,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/advanced/message.html
+++ b/docs/manual/advanced/message.html
@@ -223,7 +223,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/advanced/multi-command.html
+++ b/docs/manual/advanced/multi-command.html
@@ -209,7 +209,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/banking.html
+++ b/docs/manual/banking.html
@@ -449,7 +449,7 @@ bank.createAccount(BigDecimal.valueOf(100))
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/database-configuration.html
+++ b/docs/manual/database-configuration.html
@@ -205,7 +205,7 @@ CREATE INDEX app_emission_date_idx ON app_journal (emission_date);
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/eventually-consistent-projection.html
+++ b/docs/manual/eventually-consistent-projection.html
@@ -242,7 +242,7 @@ dependencies {
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -175,7 +175,7 @@ libraryDependencies ++= Seq(
 &lt;dependencies&gt
   &lt;dependency&gt;
     &lt;groupId&gt;fr.maif&lt;/groupId&gt;
-    &lt;artifactId&gt;common-events&lt;/artifactId&gt;
+    &lt;artifactId&gt;commons-events&lt;/artifactId&gt;
     &lt;version&gt;${thoth.version}&lt;/version&gt;
   &lt;/dependency&gt
   &lt;dependency&gt;
@@ -212,7 +212,7 @@ libraryDependencies ++= Seq(
   ThothVersion: "0.1.0*"
 ]
 dependencies {
-  implementation "fr.maif:common-events:${versions.ThothVersion}"
+  implementation "fr.maif:commons-events:${versions.ThothVersion}"
   implementation "fr.maif:thoth-core-akka:${versions.ThothVersion}"
   implementation "fr.maif:thoth-core-reactor:${versions.ThothVersion}"
   implementation "fr.maif:thoth-jooq:${versions.ThothVersion}"
@@ -327,7 +327,7 @@ dependencies {
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/kafka-consumption.html
+++ b/docs/manual/kafka-consumption.html
@@ -240,7 +240,7 @@ KafkaConsumer&lt;String, EventEnvelope&lt;BankEvent, Tuple0, Tuple0&gt;&gt; cons
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/non-blocking/banking-real-life-non-blocking.html
+++ b/docs/manual/non-blocking/banking-real-life-non-blocking.html
@@ -664,7 +664,7 @@ bank.withdraw(id, BigDecimal.valueOf(50)).toCompletableFuture().join().get().cur
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/non-blocking/index.html
+++ b/docs/manual/non-blocking/index.html
@@ -195,7 +195,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/non-blocking/projections-non-blocking.html
+++ b/docs/manual/non-blocking/projections-non-blocking.html
@@ -373,7 +373,7 @@ bank.init()
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/resilient-kafka-consumption.html
+++ b/docs/manual/resilient-kafka-consumption.html
@@ -347,7 +347,7 @@ Status status = resilientKafkaConsumer.status();
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/standard/banking-real-life.html
+++ b/docs/manual/standard/banking-real-life.html
@@ -519,7 +519,7 @@ String id = bank.createAccount(BigDecimal.valueOf(100)).toCompletableFuture().jo
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/standard/index.html
+++ b/docs/manual/standard/index.html
@@ -195,7 +195,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/standard/projections.html
+++ b/docs/manual/standard/projections.html
@@ -292,7 +292,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/docs/manual/technical-considerations.html
+++ b/docs/manual/technical-considerations.html
@@ -210,7 +210,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2022</span>
+<span class="text">&copy; 2024</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->

--- a/thoth-documentation/src/main/paradox/index.md
+++ b/thoth-documentation/src/main/paradox/index.md
@@ -50,7 +50,7 @@ This documentation focuses on implementing event-sourcing on a simple use case :
 @@dependency[sbt,Maven,Gradle] {
     symbol="ThothVersion"
     value="$project.version.short$"
-    group="fr.maif" artifact="common-events" version="ThothVersion"
+    group="fr.maif" artifact="commons-events" version="ThothVersion"
     group2="fr.maif" artifact2="thoth-core-akka" version2="ThothVersion"
     group3="fr.maif" artifact3="thoth-core-reactor" version3="ThothVersion"
     group4="fr.maif" artifact4="thoth-jooq" version4="ThothVersion"

--- a/thoth-jooq/src/main/java/fr/maif/eventsourcing/impl/PostgresEventStore.java
+++ b/thoth-jooq/src/main/java/fr/maif/eventsourcing/impl/PostgresEventStore.java
@@ -266,7 +266,7 @@ public class PostgresEventStore<E extends Event, Meta, Context> implements Event
                 .from(table(this.tableNames.tableName))
                 .where(PUBLISHED.eq(true))
                 .fetchAsync(executor)
-                .thenApply(r -> r.getValues("max", Long.class).stream().findFirst().orElse(0L));
+                .thenApply(r -> r.getValues("max", Long.class).stream().filter(Objects::nonNull).findFirst().orElse(0L));
     }
 
     @Override


### PR DESCRIPTION
Applying a `SELECT MAX(...)` on a empty table results to a single record line with a `NULL` value.
This results to a List with a single null object on the `getValues("max", Long.class)` call and throw a NPE on `.findFirst()`.

Re-generating documentation with typo in the dependencies (cf. https://github.com/MAIF/thoth/pull/59).